### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to TODOIT
+
+## Development environment
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/hipotures/todoit.git
+   cd todoit/todoit-mcp
+   ```
+2. Install in editable mode with development dependencies:
+   ```bash
+   pip install -e .[dev]
+   ```
+3. Initialize the SQLite database if needed:
+   ```bash
+   python -c "from core.manager import TodoManager; TodoManager()"
+   ```
+
+## Code style
+- Follow [PEP 8](https://peps.python.org/pep-0008/) guidelines.
+- Format code with [Black](https://github.com/psf/black) (line length 88).
+- Sort imports using [isort](https://github.com/PyCQA/isort).
+- Maintain type hints and check with [mypy](https://mypy-lang.org/).
+
+## Commit guidelines
+- Make small, focused commits.
+- Use present-tense, descriptive messages (e.g., `Add item model`).
+- Reference related issues or tasks when applicable.
+
+## Running tests
+From the `todoit-mcp` directory run:
+```bash
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ This project is released into the public domain under the [CC0 1.0 Universal](ht
 
 ## 🤝 Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development environment setup, code style, commit conventions, and testing instructions.
+
 Contributions are welcome! This project uses:
 - **Modern Python** development practices
 - **Claude Code** for AI-assisted development


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide covering dev setup, style, commits, and tests
- link README Contributing section to CONTRIBUTING.md

## Testing
- `pytest` *(fails: 22 failed, 187 passed, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6894dfa837388331aa293daf02fbaa83